### PR TITLE
한글(한자) 혼용 변환 기능 추가.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,11 @@ False
 >>> hanja.translate('大韓民國은 民主共和國이다.', 'combination-text')
 '大韓民國(대한민국)은 民主共和國(민주공화국)이다.'
 
+혼용 모드 변환 version 2 (text):
+
+>>> hanja.translate('大韓民國은 民主共和國이다.', 'combination-text-reversed')
+'대한민국(大韓民國)은 민주공화국(民主共和國)이다.'
+
 혼용 모드 변환 (HTML):
 
 >>> hanja.translate(u'大韓民國은 民主共和國이다.', 'combination-html')

--- a/hanja/impl.py
+++ b/hanja/impl.py
@@ -41,7 +41,7 @@ def split_hanja(text):
 
 
 def is_valid_mode(mode):
-    if mode in ("substitution", "combination-text", "combination-html"):
+    if mode in ("substitution", "combination-text", "combination-text-reversed", "combination-html"):
         return True
     elif mode == "combination":
         warnings.warn(
@@ -55,13 +55,15 @@ def is_valid_mode(mode):
 
 def get_format_string(mode, word):
     """
-    :param mode: substitution | combination-text | combination-html
+    :param mode: substitution | combination-text | combination-text-reversed | combination-html
     """
     if not is_valid_mode(mode):
         raise ValueError("Unsupported translation mode: " + mode)
 
     if mode == "combination-text" and is_hanja(word[0]):
         return u"{word}({translated})"
+    elif mode == "combination-text-reversed" and is_hanja(word[0]):
+        return u"{translated}({word})"
     elif mode in ("combination-html", "combination") and is_hanja(word[0]):
         return u'<span class="hanja">{word}</span><span class="hangul">({translated})</span>'
     else:


### PR DESCRIPTION
- 한글(한자) 혼용 변환 기능을 추가 하였습니다.
- `impl.py` 내의 `is_valid_mode`, `get_format_string`의 주석 또한 수정 하였습니다.
- 이에 따른 README도 수정 하였습니다.

### Example

- In

```python
hanja.translate('大韓民國은 民主共和國이다.', 'combination-text-reversed')
```

- Out

```terminal
대한민국(大韓民國)은 민주공화국(民主共和國)이다.
```
