### PR TITLE
Python 3.10에서 패키지가 설치되지 않는 문제 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.11", "3.10", "3.9", "3.8"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/hanja/hangul.py
+++ b/hanja/hangul.py
@@ -41,17 +41,17 @@ def dooeum(previous, current):
 
     # 모음이나 ㄴ 받침 뒤에 이어지는 '렬, 률'은 '열, 율'로 발음한다.
     if previous.isalnum():
-        if current in (u"렬", u"률") and is_hangul(previous) and p[2] in (0, 2):
+        if current in ("렬", "률") and is_hangul(previous) and p[2] in (0, 2):
             offset = 6
     # 한자음 '녀, 뇨, 뉴, 니', '랴, 려, 례, 료, 류, 리'가 단어 첫머리에 올 때
     # '여, 요, 유, 이', '야, 여, 예, 요, 유, 이'로 발음한다.
-    elif current_head in (u"녀", u"뇨", u"뉴", u"니"):
+    elif current_head in ("녀", "뇨", "뉴", "니"):
         offset = 9
-    elif current_head in (u"랴", u"려", u"례", u"료", u"류", u"리"):
+    elif current_head in ("랴", "려", "례", "료", "류", "리"):
         offset = 6
     # 한자음 '라, 래, 로, 뢰, 루, 르'가 단어 첫머리에 올 때 '나, 내, 노, 뇌,
     # 누, 느'로 발음한다.
-    elif current_head in (u"라", u"래", u"로", u"뢰", u"루", u"르"):
+    elif current_head in ("라", "래", "로", "뢰", "루", "르"):
         offset = -3
 
     return build(c[0] + offset, c[1], c[2])

--- a/hanja/impl.py
+++ b/hanja/impl.py
@@ -41,7 +41,12 @@ def split_hanja(text):
 
 
 def is_valid_mode(mode):
-    if mode in ("substitution", "combination-text", "combination-text-reversed", "combination-html"):
+    if mode in (
+        "substitution",
+        "combination-text",
+        "combination-text-reversed",
+        "combination-html",
+    ):
         return True
     elif mode == "combination":
         warnings.warn(
@@ -61,13 +66,13 @@ def get_format_string(mode, word):
         raise ValueError("Unsupported translation mode: " + mode)
 
     if mode == "combination-text" and is_hanja(word[0]):
-        return u"{word}({translated})"
+        return "{word}({translated})"
     elif mode == "combination-text-reversed" and is_hanja(word[0]):
-        return u"{translated}({word})"
+        return "{translated}({word})"
     elif mode in ("combination-html", "combination") and is_hanja(word[0]):
-        return u'<span class="hanja">{word}</span><span class="hangul">({translated})</span>'
+        return '<span class="hanja">{word}</span><span class="hangul">({translated})</span>'
     else:
-        return u"{translated}"
+        return "{translated}"
 
 
 def translate(text, mode):
@@ -88,7 +93,7 @@ def translate_word(word, prev, format_string):
     :param word: Word to be translated
     :param prev: Preceeding word
     """
-    prev_char = prev[-1] if prev else u" "
+    prev_char = prev[-1] if prev else " "
     buf = []
     for c in word:
         new_char = translate_syllable(prev_char, c)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==5.4
+pyyaml==6.0
 
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ with open("requirements.txt") as f:
 
 setup(
     name="hanja",
-    py_modules=["hanja/__init__", "hanja.hangul"],
+    py_modules=["hanja", "hanja/__init__", "hanja.hangul"],
     version=hanja.__version__,
     description="Hangul & Hanja library",
     long_description=readme(),
     author=hanja.__author__,
     author_email=hanja.__email__,
     url="https://github.com/suminb/hanja",
-    packages=["", "hanja"],
+    packages=[],
     package_data={"": ["requirements.txt"], "hanja": ["table.yml"]},
     include_package_data=True,
     install_requires=install_requires,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,45 +8,45 @@ from hanja import hangul
 
 
 def test_separation():
-    assert hangul.separate(u"가") == (0, 0, 0)
-    assert hangul.separate(u"까") == (1, 0, 0)
-    assert hangul.separate(u"갸") == (0, 2, 0)
-    assert hangul.separate(u"각") == (0, 0, 1)
+    assert hangul.separate("가") == (0, 0, 0)
+    assert hangul.separate("까") == (1, 0, 0)
+    assert hangul.separate("갸") == (0, 2, 0)
+    assert hangul.separate("각") == (0, 0, 1)
 
 
 def test_build():
-    assert hangul.build(0, 0, 0) == u"가"
+    assert hangul.build(0, 0, 0) == "가"
 
 
 def test_is_hangul():
-    assert hangul.is_hangul(u"한")
+    assert hangul.is_hangul("한")
     assert not hangul.is_hangul("A")
     assert not hangul.is_hangul("1")
     assert not hangul.is_hangul(None)
 
 
 def test_contains_hangul():
-    assert hangul.contains_hangul(u"한국어")
-    assert hangul.contains_hangul(u"한ABC국어")
-    assert not hangul.contains_hangul(u"Yo, what's up bro?")
-    assert not hangul.contains_hangul(u"1234567890")
+    assert hangul.contains_hangul("한국어")
+    assert hangul.contains_hangul("한ABC국어")
+    assert not hangul.contains_hangul("Yo, what's up bro?")
+    assert not hangul.contains_hangul("1234567890")
 
 
 def test_is_hanja():
-    assert not hanja.is_hanja(u"한")
+    assert not hanja.is_hanja("한")
     assert not hanja.is_hanja("A")
     assert not hanja.is_hanja("1")
     assert not hanja.is_hanja(None)
-    assert hanja.is_hanja(u"韓")
+    assert hanja.is_hanja("韓")
 
 
 def test_split_hanja():
-    corpora = list(hanja.split_hanja(u"大韓民國은 民主共和國이다."))
+    corpora = list(hanja.split_hanja("大韓民國은 民主共和國이다."))
     assert len(corpora) == 4
-    assert corpora[0] == u"大韓民國"
-    assert corpora[1] == u"은 "
-    assert corpora[2] == u"民主共和國"
-    assert corpora[3] == u"이다."
+    assert corpora[0] == "大韓民國"
+    assert corpora[1] == "은 "
+    assert corpora[2] == "民主共和國"
+    assert corpora[3] == "이다."
 
 
 def test_is_valid_mode():
@@ -58,39 +58,40 @@ def test_is_valid_mode():
 
 def test_translate_substitution_mode():
     mode = "substitution"
-    assert hanja.translate(u"韓國語", mode=mode) == u"한국어"
-    assert hanja.translate(u"한국어", mode=mode) == u"한국어"
-    assert hanja.translate(u"利用해", mode=mode) == u"이용해"
-    assert hanja.translate(u"連結된", mode=mode) == u"연결된"
-    assert hanja.translate(u"1800年에", mode=mode) == u"1800년에"
-    assert hanja.translate(u"그레고리曆", mode=mode) == u"그레고리력"
-    assert hanja.translate(u"系列", mode=mode) == u"계열"
+    assert hanja.translate("韓國語", mode=mode) == "한국어"
+    assert hanja.translate("한국어", mode=mode) == "한국어"
+    assert hanja.translate("利用해", mode=mode) == "이용해"
+    assert hanja.translate("連結된", mode=mode) == "연결된"
+    assert hanja.translate("1800年에", mode=mode) == "1800년에"
+    assert hanja.translate("그레고리曆", mode=mode) == "그레고리력"
+    assert hanja.translate("系列", mode=mode) == "계열"
 
 
 def test_translate_combination_text_mode():
     mode = "combination-text"
-    assert hanja.translate(u"韓國語", mode=mode) == u"韓國語(한국어)"
-    assert hanja.translate(u"利用해", mode=mode) == u"利用(이용)해"
+    assert hanja.translate("韓國語", mode=mode) == "韓國語(한국어)"
+    assert hanja.translate("利用해", mode=mode) == "利用(이용)해"
     assert (
-        hanja.translate(u"大韓民國은 民主共和國이다.", mode=mode) == u"大韓民國(대한민국)은 民主共和國(민주공화국)이다."
+        hanja.translate("大韓民國은 民主共和國이다.", mode=mode)
+        == "大韓民國(대한민국)은 民主共和國(민주공화국)이다."
     )
 
 
 @pytest.mark.parametrize("mode", ["combination-html", "combination"])
 def test_translate_combination_html_mode(mode):
     assert (
-        hanja.translate(u"韓國語", mode=mode)
-        == u'<span class="hanja">韓國語</span><span class="hangul">(한국어)</span>'
+        hanja.translate("韓國語", mode=mode)
+        == '<span class="hanja">韓國語</span><span class="hangul">(한국어)</span>'
     )
     assert (
-        hanja.translate(u"利用해", mode=mode)
-        == u'<span class="hanja">利用</span><span class="hangul">(이용)</span>해'
+        hanja.translate("利用해", mode=mode)
+        == '<span class="hanja">利用</span><span class="hangul">(이용)</span>해'
     )
     assert (
-        hanja.translate(u"大韓民國은 民主共和國이다.", mode=mode)
-        == u'<span class="hanja">大韓民國</span><span class="hangul">(대한민국)'
-        u'</span>은 <span class="hanja">民主共和國</span><span class="hangul">'
-        u"(민주공화국)</span>이다."
+        hanja.translate("大韓民國은 民主共和國이다.", mode=mode)
+        == '<span class="hanja">大韓民國</span><span class="hangul">(대한민국)'
+        '</span>은 <span class="hanja">民主共和國</span><span class="hangul">'
+        "(민주공화국)</span>이다."
     )
 
 


### PR DESCRIPTION
- 사용자가 리포트 해준 문제: Google Colab에서 Hanja 패키지가 설치되지 않음
- 원인: PyYAML 5.1 버전은 Python 3.8까지밖에 지원하지 못함
- 조치: PyYAML 6.0 버전으로 업그레이드
  - Hanja 패키지도 파이썬 3.11, 3.10 등 최신 버전 지원하도록 조치