### PR TITLE
Add automated wheel build in GitHub Actions.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build_dist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build dist and wheel
+        run: pipx run build --sdist --wheel
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-dist
+          path: dist/*
+
+  # upload_pypi:
+  #   needs: [build_dist]
+  #   runs-on: [self-hosted, linux, x64, cpu-only]
+  #   environment: release
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: cibw-*
+  #         path: dist
+  #         merge-multiple: true
+
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+
+  upload_release:
+    needs: [build_dist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*


### PR DESCRIPTION
https://github.com/suminb/hanja/issues/27
https://github.com/suminb/hanja/issues/26

다음의 이슈때문에 자동화된 wheel build를 위해 git version tag push 하면 wheel 이 빌드되도록 만들어두었습니다.

@suminb 주석처리해둔 부분을 해제하고 pypi에 package owner 인증을 받으면 git tag 를 하면 pypi로도 자동 업로드 됩니다.


fork에 release된 wheel을 통해서 잘 빌드 된 것을 확인할 수 있습니다.
https://github.com/kimdwkimdw/hanja/releases/tag/v0.14.1

```
pip install https://github.com/kimdwkimdw/hanja/releases/download/v0.14.1/hanja-0.14.1-py3-none-any.whl
```